### PR TITLE
Remove live feed feature 

### DIFF
--- a/ISSTracker/Screens/TrackISSVC.swift
+++ b/ISSTracker/Screens/TrackISSVC.swift
@@ -26,18 +26,12 @@ class TrackISSVC: UIViewController {
     var pulseLayer = CAShapeLayer()
 
     var isOrbitPathEnabled = true
-    var isShowingLiveFeed = false
-
-    let player = AVPlayer(url: URL(string: "http://iphone-streaming.ustream.tv/uhls/17074538/streams/live/iphone/playlist.m3u8")!)
-    var playerLayer: AVPlayerLayer!
-    var playerYCoordinate: CGFloat = 0
 
     let iconWidth = UserDefaultsManager.largeMapAnnotations ? 90 : 60
     let iconHeight = UserDefaultsManager.largeMapAnnotations ? 60 : 40
 
     var mapTypeButton = ITIconButton(backgroundColor: Colors.mainBlueYellow, image: (UIImage(systemName: "map", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal))!.withTintColor(.systemBackground))
     var showCoordinatesButton = ITIconButton(backgroundColor: Colors.mainBlueYellow, image: (UIImage(systemName: "note.text", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal))!.withTintColor(.systemBackground))
-    var showLiveFeedButton = ITIconButton(backgroundColor: Colors.mainBlueYellow, image: (UIImage(systemName: "video", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal))!.withTintColor(.systemBackground))
     var orbitPathButton = ITIconButton(backgroundColor: Colors.mainBlueYellow, image: (UIImage(systemName: "location.north.line", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal))!.withTintColor(.systemBackground))
     var zoomInButton = ITIconButton(backgroundColor: Colors.mainBlueYellow, image: (UIImage(systemName: "plus.magnifyingglass", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal))!.withTintColor(.systemBackground))
     var zoomOutButton = ITIconButton(backgroundColor: Colors.mainBlueYellow, image: (UIImage(systemName: "minus.magnifyingglass", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal))!.withTintColor(.systemBackground))
@@ -86,7 +80,6 @@ class TrackISSVC: UIViewController {
         configureCoordinatesView()
         configureMapTypeButton()
         configureShowCoordinatesButton()
-        configureShowLiveFeedButton()
         configureOrbitPathButton()
         configureZoomInButton()
         configureZoomOutButton()
@@ -95,28 +88,6 @@ class TrackISSVC: UIViewController {
         getFutureLocations()
 
         addBackgroundandForegroundObservers()
-
-        playVideo()
-    }
-
-    func playVideo() {
-
-        player.allowsExternalPlayback = true
-        playerLayer = AVPlayerLayer(player: player)
-        let width = view.bounds.width
-        playerYCoordinate = view.center.y + (view.bounds.height/2)
-        playerLayer.frame = CGRect(x: view.center.x - width/2, y: playerYCoordinate, width: width, height: 260)
-        playerLayer.masksToBounds = true
-        playerLayer.borderWidth = 2
-        playerLayer.borderColor = Colors.mainBlueYellow.cgColor
-        playerLayer.videoGravity = .resizeAspectFill
-        player.automaticallyWaitsToMinimizeStalling = false
-
-        view.layer.insertSublayer(playerLayer, at: 1)
-
-        UIView.animate(withDuration: 1.0, delay: 1.0, options: UIView.AnimationOptions.curveEaseIn, animations: {
-            self.view.alpha = 1.0
-        }, completion: nil)
     }
 
     func addBackgroundandForegroundObservers() {
@@ -134,13 +105,11 @@ class TrackISSVC: UIViewController {
         let coordinates = CLLocationCoordinate2D(latitude: CLLocationDegrees(issLocation.latitude), longitude: CLLocationDegrees(issLocation.longitude))
         let region = MKCoordinateRegion(center: coordinates, latitudinalMeters: CLLocationDistance(8000000), longitudinalMeters: CLLocationDistance(8000000))
         Map.mapView.setRegion(region, animated: true)
-        if isShowingLiveFeed { player.play() }
         if isOrbitPathEnabled { updateOrbitPathOverlays()}
     }
 
     @objc func didEnterBackground(){
         clearPulseLayer()
-        player.pause()
     }
 
     @objc func clearPulseLayer(){
@@ -336,38 +305,6 @@ class TrackISSVC: UIViewController {
         }
     }
 
-    func configureShowLiveFeedButton(){
-        view.addSubview(showLiveFeedButton)
-        addActionToShowLiveFeedButton()
-        NSLayoutConstraint.activate([
-            showLiveFeedButton.widthAnchor.constraint(equalToConstant: 45),
-            showLiveFeedButton.heightAnchor.constraint(equalToConstant: 45),
-            showLiveFeedButton.leadingAnchor.constraint(equalTo: Map.mapView.leadingAnchor, constant: 10),
-            showLiveFeedButton.topAnchor.constraint(equalTo: showCoordinatesButton.bottomAnchor, constant: 10)
-        ])
-    }
-
-    func addActionToShowLiveFeedButton(){
-        showLiveFeedButton.addTarget(self, action: #selector(showLiveFeedButtonTapped), for: .touchUpInside)
-    }
-
-    @objc func showLiveFeedButtonTapped(){
-        showLiveFeedButton.pulsate()
-        UIView.animate(withDuration: 0.2) { [weak self] in
-            guard let self = self else { return }
-            switch self.isShowingLiveFeed {
-            case false:
-                self.playerYCoordinate = self.view.center.y + (self.view.bounds.height/2) - 260
-                self.playerLayer.frame = CGRect(x: self.view.center.x - (self.view.bounds.width/2), y: self.playerYCoordinate, width: self.view.bounds.width, height: 260)
-                self.player.play()
-            case true:
-                self.playerYCoordinate = self.view.center.y + (self.view.bounds.height/2)
-                self.playerLayer.frame = CGRect(x: self.view.center.x - (self.view.bounds.width/2), y: self.playerYCoordinate, width: self.view.bounds.width, height: 260)
-            }
-        }
-        isShowingLiveFeed.toggle()
-    }
-
     func configureZoomInButton(){
         view.addSubview(zoomInButton)
         addActionToZoomInButton()
@@ -426,7 +363,7 @@ class TrackISSVC: UIViewController {
         NSLayoutConstraint.activate([
             orbitPathButton.widthAnchor.constraint(equalToConstant: 45),
             orbitPathButton.heightAnchor.constraint(equalToConstant: 45),
-            orbitPathButton.topAnchor.constraint(equalTo: showLiveFeedButton.bottomAnchor, constant: 10),
+            orbitPathButton.topAnchor.constraint(equalTo: showCoordinatesButton.bottomAnchor, constant: 10),
             orbitPathButtonLeadingConstraint
         ])
     }


### PR DESCRIPTION
This PR removes the live feed feature, as the iPhone-specific streaming link is no longer supported. Hopefully, this can be added back in the future.