### PR TITLE
Add default image query to image search

### DIFF
--- a/ISSTracker.xcodeproj/project.pbxproj
+++ b/ISSTracker.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		B23246F026376DDE000EF307 /* darkBlueIcon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B23246ED26376DDE000EF307 /* darkBlueIcon@2x.png */; };
 		B23246F126376DDE000EF307 /* darkBlueIcon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = B23246EE26376DDE000EF307 /* darkBlueIcon@3x.png */; };
 		B23246FC26377105000EF307 /* IconManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23246FB26377105000EF307 /* IconManager.swift */; };
+		B234A9EF26E6F65C0042DE7B /* Ext+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = B234A9EE26E6F65C0042DE7B /* Ext+String.swift */; };
 		B26A21B8265893BA00488DE8 /* SearchImagesVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A21B7265893BA00488DE8 /* SearchImagesVC.swift */; };
 		B26A21BA2658945F00488DE8 /* NASAImageSearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A21B92658945F00488DE8 /* NASAImageSearchResults.swift */; };
 		B26A21BC265895D100488DE8 /* ITNasaImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A21BB265895D100488DE8 /* ITNasaImageView.swift */; };
@@ -187,6 +188,7 @@
 		B23246ED26376DDE000EF307 /* darkBlueIcon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "darkBlueIcon@2x.png"; sourceTree = "<group>"; };
 		B23246EE26376DDE000EF307 /* darkBlueIcon@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "darkBlueIcon@3x.png"; sourceTree = "<group>"; };
 		B23246FB26377105000EF307 /* IconManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconManager.swift; sourceTree = "<group>"; };
+		B234A9EE26E6F65C0042DE7B /* Ext+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ext+String.swift"; sourceTree = "<group>"; };
 		B26A21B7265893BA00488DE8 /* SearchImagesVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchImagesVC.swift; sourceTree = "<group>"; };
 		B26A21B92658945F00488DE8 /* NASAImageSearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NASAImageSearchResults.swift; sourceTree = "<group>"; };
 		B26A21BB265895D100488DE8 /* ITNasaImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITNasaImageView.swift; sourceTree = "<group>"; };
@@ -330,6 +332,7 @@
 				B21D0DBD25F6C53400A87141 /* Ext+UIViewController.swift */,
 				B232463326274342000EF307 /* Ext+Array.swift */,
 				B2324652262CAC6F000EF307 /* Ext+MKAnnotationView.swift */,
+				B234A9EE26E6F65C0042DE7B /* Ext+String.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -731,6 +734,7 @@
 				B232463E2628BACB000EF307 /* ITAstronautCell.swift in Sources */,
 				B21D0D9825F6BD2500A87141 /* PassTime.swift in Sources */,
 				B2324653262CAC6F000EF307 /* Ext+MKAnnotationView.swift in Sources */,
+				B234A9EF26E6F65C0042DE7B /* Ext+String.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ISSTracker/Extensions/Ext+String.swift
+++ b/ISSTracker/Extensions/Ext+String.swift
@@ -1,0 +1,17 @@
+//
+//  Ext+String.swift
+//  ISSTracker
+//
+//  Created by Sam McGarry on 9/6/21.
+//
+
+import Foundation
+
+extension String {
+
+    func safeSearchQuery() -> String {
+        let excludedCharacters = CharacterSet(charactersIn: "“”<>‘’&%^{}\\`")
+        let components = self.components(separatedBy: excludedCharacters)
+        return components.joined(separator: "")
+    }
+}


### PR DESCRIPTION
This PR adds a default image query to the image search feature. When the user pulls up the search view, it will display recent images from the ISS from the current calendar year.