### PR TITLE
Add image descriptions, refine image viewer

### DIFF
--- a/ISSTracker/Extensions/Ext+UIView.swift
+++ b/ISSTracker/Extensions/Ext+UIView.swift
@@ -21,4 +21,26 @@ extension UIView {
             bottomAnchor.constraint(equalTo: superview.bottomAnchor)
         ])
     }
+
+    func fadeIn(_ duration: TimeInterval? = 0.2, onCompletion: (() -> Void)? = nil) {
+        self.alpha = 0
+        self.isHidden = false
+        UIView.animate(withDuration: duration!,
+                       animations: { self.alpha = 1 },
+                       completion: { (value: Bool) in
+                          if let complete = onCompletion { complete() }
+                       }
+        )
+    }
+
+    func fadeOut(_ duration: TimeInterval? = 0.2, onCompletion: (() -> Void)? = nil) {
+        UIView.animate(withDuration: duration!,
+                       animations: { self.alpha = 0 },
+                       completion: { (value: Bool) in
+                           self.isHidden = true
+                           if let complete = onCompletion { complete() }
+                       }
+        )
+    }
 }
+

--- a/ISSTracker/Model/NASAImageSearchResults.swift
+++ b/ISSTracker/Model/NASAImageSearchResults.swift
@@ -22,7 +22,11 @@ struct Collection: Codable {
 }
 
 // MARK: - Item
-struct Item: Codable, Hashable {
+struct Item: Codable, Hashable, Identifiable {
+    let id = UUID()
+
+    private enum CodingKeys : String, CodingKey { case data, href, links }
+
     let data: [NASAdata]
     let href: String
     let links: [ItemLink]

--- a/ISSTracker/Screens/ImageViewerVC.swift
+++ b/ISSTracker/Screens/ImageViewerVC.swift
@@ -10,8 +10,10 @@ import UIKit
 class ImageViewerVC: UIViewController {
 
     var nasaImageView = ITNasaImageView(frame: .zero)
+    var nasaImageDescriptionLabel = ITBodyLabel(textAlignment: .left)
     var scrollView = UIScrollView()
     var contentView = UIView()
+    var blurEffectView = UIVisualEffectView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,20 +23,21 @@ class ImageViewerVC: UIViewController {
     func configure(){
         configureViewController()
         configureScrollView()
-        configureNasaImageView()
+        configureNASAImageView()
+        configureNASADescriptionLabel()
+        configureBlurView()
     }
 
     func configureViewController(){
-        title = "Image Viewer"
         view.backgroundColor = .systemGray6
 
         let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissVC))
-        navigationItem.rightBarButtonItem = doneButton
-
         let shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(shareImage))
-        navigationItem.leftBarButtonItem = shareButton
+        let descriptionButton = UIBarButtonItem(image: UIImage(systemName: "info.circle"), style: .plain, target: self, action: #selector(showNASADescription))
 
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "NasalizationRg-Regular", size: 20)!]
+        navigationItem.rightBarButtonItems = [doneButton, shareButton, descriptionButton]
+
+        self.navigationController?.navigationBar.prefersLargeTitles = false
     }
 
     func configureScrollView(){
@@ -60,12 +63,12 @@ class ImageViewerVC: UIViewController {
         scrollView.addGestureRecognizer(longPressGest)
     }
 
-    func configureNasaImageView(){
+    func configureNASAImageView(){
         scrollView.addSubview(nasaImageView)
 
         NSLayoutConstraint.activate([
             nasaImageView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
-            nasaImageView.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor, constant: -view.bounds.width * 0.08),
+            nasaImageView.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor, constant: -view.bounds.height * 0.1),
             nasaImageView.widthAnchor.constraint(equalToConstant: view.bounds.width),
             nasaImageView.heightAnchor.constraint(equalToConstant: view.bounds.height * 0.75)
         ])
@@ -79,6 +82,29 @@ class ImageViewerVC: UIViewController {
         nasaImageView.contentMode = .scaleAspectFit
     }
 
+    func configureNASADescriptionLabel(){
+        view.addSubview(nasaImageDescriptionLabel)
+        nasaImageDescriptionLabel.numberOfLines = 0
+        nasaImageDescriptionLabel.textColor = .white
+        nasaImageDescriptionLabel.isHidden = true
+
+        NSLayoutConstraint.activate([
+            nasaImageDescriptionLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            nasaImageDescriptionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nasaImageDescriptionLabel.widthAnchor.constraint(equalToConstant: view.bounds.width * 0.8),
+            nasaImageDescriptionLabel.heightAnchor.constraint(equalToConstant: 400)
+        ])
+    }
+
+    func configureBlurView() {
+        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
+        blurEffectView = UIVisualEffectView(effect: blurEffect)
+        blurEffectView.frame = view.bounds
+        blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        blurEffectView.isHidden = true
+        scrollView.addSubview(blurEffectView)
+    }
+
     @objc func shareImage(){
         let img: UIImage = nasaImageView.image!
         let shareItems: Array = [img]
@@ -90,6 +116,17 @@ class ImageViewerVC: UIViewController {
 
     @objc func dismissVC(){
         self.dismiss(animated: true)
+    }
+
+    @objc func showNASADescription() {
+        scrollView.isUserInteractionEnabled.toggle()
+        if blurEffectView.isHidden {
+            blurEffectView.fadeIn()
+            nasaImageDescriptionLabel.fadeIn()
+        } else {
+            blurEffectView.fadeOut()
+            nasaImageDescriptionLabel.fadeOut()
+        }
     }
 
     @objc func handleDoubleTapScrollView(recognizer: UITapGestureRecognizer) {

--- a/ISSTracker/Screens/SearchImagesVC.swift
+++ b/ISSTracker/Screens/SearchImagesVC.swift
@@ -234,8 +234,8 @@ extension SearchImagesVC: UICollectionViewDelegate, UICollectionViewDelegateFlow
 
         let imageViewerVC = ImageViewerVC()
         imageViewerVC.nasaImageView.downloadNasaImage(fromURL: image!.links[0].href)
-        let navController = UINavigationController(rootViewController: imageViewerVC)
-        self.present(navController, animated: true)
+        imageViewerVC.nasaImageDescriptionLabel.text = image!.data[0].description
+        self.navigationController?.pushViewController(imageViewerVC, animated: true)
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {


### PR DESCRIPTION
This PR adds the ability to view descriptions for images that are returned in the image search section. The description is provided by NASA's API, and is toggled by tapping an info button in the Image Viewer.