### PR TITLE
Implement RevenueCat and tipping options

### DIFF
--- a/ISSTracker.xcodeproj/project.pbxproj
+++ b/ISSTracker.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -82,6 +82,9 @@
 		B23246F126376DDE000EF307 /* darkBlueIcon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = B23246EE26376DDE000EF307 /* darkBlueIcon@3x.png */; };
 		B23246FC26377105000EF307 /* IconManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23246FB26377105000EF307 /* IconManager.swift */; };
 		B234A9EF26E6F65C0042DE7B /* Ext+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = B234A9EE26E6F65C0042DE7B /* Ext+String.swift */; };
+		B234A9F126ED6A580042DE7B /* IAPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B234A9F026ED6A580042DE7B /* IAPManager.swift */; };
+		B234A9F426ED6B990042DE7B /* Purchases in Frameworks */ = {isa = PBXBuildFile; productRef = B234A9F326ED6B990042DE7B /* Purchases */; };
+		B234A9F626ED6E250042DE7B /* TipVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B234A9F526ED6E250042DE7B /* TipVC.swift */; };
 		B26A21B8265893BA00488DE8 /* SearchImagesVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A21B7265893BA00488DE8 /* SearchImagesVC.swift */; };
 		B26A21BA2658945F00488DE8 /* NASAImageSearchResults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A21B92658945F00488DE8 /* NASAImageSearchResults.swift */; };
 		B26A21BC265895D100488DE8 /* ITNasaImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26A21BB265895D100488DE8 /* ITNasaImageView.swift */; };
@@ -189,6 +192,8 @@
 		B23246EE26376DDE000EF307 /* darkBlueIcon@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "darkBlueIcon@3x.png"; sourceTree = "<group>"; };
 		B23246FB26377105000EF307 /* IconManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconManager.swift; sourceTree = "<group>"; };
 		B234A9EE26E6F65C0042DE7B /* Ext+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ext+String.swift"; sourceTree = "<group>"; };
+		B234A9F026ED6A580042DE7B /* IAPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAPManager.swift; sourceTree = "<group>"; };
+		B234A9F526ED6E250042DE7B /* TipVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipVC.swift; sourceTree = "<group>"; };
 		B26A21B7265893BA00488DE8 /* SearchImagesVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchImagesVC.swift; sourceTree = "<group>"; };
 		B26A21B92658945F00488DE8 /* NASAImageSearchResults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NASAImageSearchResults.swift; sourceTree = "<group>"; };
 		B26A21BB265895D100488DE8 /* ITNasaImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ITNasaImageView.swift; sourceTree = "<group>"; };
@@ -204,6 +209,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B234A9F426ED6B990042DE7B /* Purchases in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -271,6 +277,7 @@
 				B2247626264D8E1D0031BD39 /* DeveloperVC.swift */,
 				B26A21B7265893BA00488DE8 /* SearchImagesVC.swift */,
 				B2D7D44F2658B49E008FAB15 /* ImageViewerVC.swift */,
+				B234A9F526ED6E250042DE7B /* TipVC.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -307,6 +314,7 @@
 				B21D0D9225F6B29700A87141 /* NetworkManager.swift */,
 				B23246712630B9F6000EF307 /* UserDefaultsManager.swift */,
 				B23246FB26377105000EF307 /* IconManager.swift */,
+				B234A9F026ED6A580042DE7B /* IAPManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -541,6 +549,9 @@
 			dependencies = (
 			);
 			name = ISSTracker;
+			packageProductDependencies = (
+				B234A9F326ED6B990042DE7B /* Purchases */,
+			);
 			productName = ISSTracker;
 			productReference = B21D0CF425F55F5A00A87141 /* ISSTracker.app */;
 			productType = "com.apple.product-type.application";
@@ -612,6 +623,9 @@
 				Base,
 			);
 			mainGroup = B21D0CEB25F55F5900A87141;
+			packageReferences = (
+				B234A9F226ED6B990042DE7B /* XCRemoteSwiftPackageReference "purchases-ios" */,
+			);
 			productRefGroup = B21D0CF525F55F5A00A87141 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -704,6 +718,7 @@
 				B21D0E2025FD648700A87141 /* InfoVC.swift in Sources */,
 				B26A21BA2658945F00488DE8 /* NASAImageSearchResults.swift in Sources */,
 				B21D0D9325F6B29700A87141 /* NetworkManager.swift in Sources */,
+				B234A9F126ED6A580042DE7B /* IAPManager.swift in Sources */,
 				B21D0D3725F562B100A87141 /* MainVC.swift in Sources */,
 				B21D0DB025F6C35500A87141 /* ITBodyLabel.swift in Sources */,
 				B21D0D6425F5908600A87141 /* ITButton.swift in Sources */,
@@ -717,6 +732,7 @@
 				B232465B262F6340000EF307 /* ITIconButton.swift in Sources */,
 				B26A21BC265895D100488DE8 /* ITNasaImageView.swift in Sources */,
 				B2D7D4502658B49E008FAB15 /* ImageViewerVC.swift in Sources */,
+				B234A9F626ED6E250042DE7B /* TipVC.swift in Sources */,
 				B2247625264CED730031BD39 /* ITPaddingLabel.swift in Sources */,
 				B21D0DBE25F6C53400A87141 /* Ext+UIViewController.swift in Sources */,
 				B21D0DB625F6C49900A87141 /* ITAlertContainerView.swift in Sources */,
@@ -1061,6 +1077,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B234A9F226ED6B990042DE7B /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RevenueCat/purchases-ios.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.12.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		B234A9F326ED6B990042DE7B /* Purchases */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B234A9F226ED6B990042DE7B /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = Purchases;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = B21D0CEC25F55F5900A87141 /* Project object */;
 }

--- a/ISSTracker/Extensions/Ext+String.swift
+++ b/ISSTracker/Extensions/Ext+String.swift
@@ -5,7 +5,7 @@
 //  Created by Sam McGarry on 9/6/21.
 //
 
-import Foundation
+import UIKit
 
 extension String {
 
@@ -13,5 +13,17 @@ extension String {
         let excludedCharacters = CharacterSet(charactersIn: "“”<>‘’&%^{}\\`")
         let components = self.components(separatedBy: excludedCharacters)
         return components.joined(separator: "")
+    }
+
+    func image() -> UIImage? {
+        let size = CGSize(width: 30, height: 30)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        UIColor.white.set()
+        let rect = CGRect(origin: .zero, size: size)
+        UIRectFill(CGRect(origin: .zero, size: size))
+        (self as AnyObject).draw(in: rect, withAttributes: [.font: UIFont.systemFont(ofSize: 26)])
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return image
     }
 }

--- a/ISSTracker/Managers/IAPManager.swift
+++ b/ISSTracker/Managers/IAPManager.swift
@@ -1,0 +1,35 @@
+//
+//  IAPManager.swift
+//  ISSTracker
+//
+//  Created by Sam McGarry on 9/11/21.
+//
+
+import Purchases
+
+class IAPManager {
+    static let shared = IAPManager()
+
+    var packages: [Purchases.Package] = []
+    var inPaymentProgress: Bool = false
+
+    init() {
+        Purchases.logLevel = .debug
+        Purchases.configure(withAPIKey: "JzcFNIVGyIDMVGOFyrLHEpIWFpByZkpe")
+        Purchases.shared.offerings { (offerings, _) in
+            if let packages = offerings?.current?.availablePackages {
+                self.packages = packages
+            }
+        }
+    }
+
+    func purchase(product: Purchases.Package, completion: @escaping () -> Void) {
+        guard !inPaymentProgress else { return }
+        inPaymentProgress = true
+        Purchases.shared.purchasePackage(product) { (_, purchaserInfo, _, _) in
+            self.inPaymentProgress = false
+        }
+    }
+}
+
+

--- a/ISSTracker/Screens/SettingsVC.swift
+++ b/ISSTracker/Screens/SettingsVC.swift
@@ -176,6 +176,12 @@ class SettingsVC: UIViewController {
         cell.imageView?.image = UIImage(systemName: "person", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal).withTintColor(Colors.mainBlueYellow)
         cell.accessoryType = .disclosureIndicator
         cells[4].append(cell)
+
+        let cell1 = UITableViewCell(style: .default, reuseIdentifier: "cell")
+        cell1.textLabel?.text = "Leave a tip"
+        cell1.imageView?.image = UIImage(systemName: "dollarsign.circle", withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .regular, scale: .small))?.withRenderingMode(.alwaysOriginal).withTintColor(Colors.mainBlueYellow)
+        cell1.accessoryType = .disclosureIndicator
+        cells[4].append(cell1)
     }
 
     @objc func switchChanged(_ sender : UISwitch!){
@@ -227,7 +233,7 @@ extension SettingsVC: UITableViewDelegate, UITableViewDataSource {
         case 0:
             let appIconSelectorVC = AppIconSelectorVC()
             self.navigationController?.pushViewController(appIconSelectorVC, animated: true)
-        case 4:
+        case 3:
             var url = URL(string: "")
             switch indexPath.row {
             case 0:
@@ -244,9 +250,17 @@ extension SettingsVC: UITableViewDelegate, UITableViewDataSource {
             let safariVC = SFSafariViewController(url: url!)
             safariVC.preferredControlTintColor = Colors.mainBlueYellow
             present(safariVC, animated: true)
-        case 5:
-            let developerVC = DeveloperVC()
-            self.navigationController?.pushViewController(developerVC, animated: true)
+        case 4:
+            switch indexPath.row {
+            case 0:
+                let developerVC = DeveloperVC()
+                self.navigationController?.pushViewController(developerVC, animated: true)
+            case 1:
+                let tipVC = TipVC()
+                self.navigationController?.pushViewController(tipVC, animated: true)
+            default:
+                break
+            }
         default:
             break
         }

--- a/ISSTracker/Screens/TipVC.swift
+++ b/ISSTracker/Screens/TipVC.swift
@@ -1,0 +1,117 @@
+//
+//  TipVC.swift
+//  ISSTracker
+//
+//  Created by Sam McGarry on 9/11/21.
+//
+
+import UIKit
+
+class TipVC: UIViewController {
+
+    let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    var cells = [UITableViewCell]()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+    }
+
+    func configure() {
+        configureViewController()
+        configureTableView()
+    }
+
+    func configureViewController() {
+        title = "Leave a Tip"
+        view.backgroundColor = .systemBackground
+
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "NasalizationRg-Regular", size: 20)!]
+    }
+
+    func configureTableView() {
+        view.addSubview(tableView)
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.frame = view.frame
+        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 60, right: 0)
+
+        configureCells()
+
+        let footerView = UIView(frame: CGRect(x: 0, y: 0, width: 200, height: 150))
+        let label = ITTitleLabel(textAlignment: .center, fontSize: 16)
+        label.text = "Enjoying the app? If you'd like, you can leave a tip to support the development of the app. It's just me building TrackISS, so anything helps :)"
+        label.textColor = .label
+        label.numberOfLines = 6
+        footerView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.heightAnchor.constraint(equalToConstant: 150),
+            label.widthAnchor.constraint(equalToConstant: 300),
+            label.centerXAnchor.constraint(equalTo: footerView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: footerView.centerYAnchor)
+        ])
+
+        tableView.tableFooterView = footerView
+    }
+
+    func configureCells() {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: "cell")
+        cell.textLabel?.text = "$1.99 - Launchpad Tip"
+        cell.imageView?.image = "🌎".image()
+        cell.selectionStyle = .none
+
+        cells.append(cell)
+
+//        let cell1 = UITableViewCell(style: .default, reuseIdentifier: "cell")
+//        cell1.textLabel?.text = "$4.99 - Rocket Tip"
+//        cell1.imageView?.image = "🚀".image()
+//        cell1.selectionStyle = .none
+//
+//        cells.append(cell1)
+//
+//        let cell2 = UITableViewCell(style: .default, reuseIdentifier: "cell")
+//        cell2.textLabel?.text = "$8.99 - Space Tip"
+//        cell2.imageView?.image = "🛰".image()
+//        cell2.selectionStyle = .none
+//
+//        cells.append(cell2)
+    }
+
+    @objc func dismissVC(){
+        dismiss(animated: true)
+    }
+}
+
+extension TipVC: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return cells[indexPath.row]
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let packages = IAPManager.shared.packages
+        print(packages)
+        print(packages.count)
+        guard packages.count == 1 else { return }
+        switch indexPath.row {
+        case 0:
+            IAPManager.shared.purchase(product: packages[0]) {
+                self.presentITAlertOnMainThread(title: "Success!", message: "You left a tip of $1.99. Thanks for your support!", buttonTitle: "Ok")
+            }
+//        case 1:
+//            IAPManager.shared.purchase(product: packages[1]) {
+//                self.presentITAlertOnMainThread(title: "Success!", message: "You left a tip of $4.99. Thanks for your support!", buttonTitle: "Ok")
+//            }
+//        case 2:
+//            IAPManager.shared.purchase(product: packages[2]) {
+//                self.presentITAlertOnMainThread(title: "Success!", message: "You left a tip of $8.99. Thanks for your support!", buttonTitle: "Ok")
+//            }
+        default:
+            break
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implements RevenueCat and adds tipping options to the app. Although I have three tipping options planned, I only have 1 implemented right now, as that is all Apple will allow in this uploaded version. Once that is approved, I will add the other two. 